### PR TITLE
コードレビューの指摘された内容の修正

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,45 +1,8 @@
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import { useEffect, useState } from 'react'
-import { Link } from 'react-router-dom';
-import './App.css'
-import Header from './Header/Header';
+import Home from './Home/Home';
 import ThreadsCreate from './ThreadsCreate/ThreadsCreate';
 
-type Threads = {
-  id: number;
-  title: string;
-}
-
-const Home = () => {
-  const [threads, setThreads] = useState<Threads[]>([]);
-
-  useEffect(() => {
-    fetch("https://railway.bulletinboard.techtrain.dev/threads?offset=20")
-      .then(res => res.json())
-      .then(data => setThreads(data))
-      .catch(error => {
-        console.log("スレッドのデータを取得できません", error)
-      })
-  }, []);
-  console.log(threads)
-  return (
-    <>
-      <Header>
-        <Link to="/threads/new" className='threadCreateLink' >スレッドをたてる</Link>
-      </Header >
-      <section className='threadContainer'>
-        <h1>新着スレッド</h1>
-        <ul>
-          {threads.map(thread => (
-            <li className='threadCord' key={thread.id}>{thread.title}</li>
-          ))}
-        </ul>
-      </section>
-    </>
-  )
-}
-
-function App() {
+export default function App() {
   return (
     <Router>
       <Routes>
@@ -49,5 +12,3 @@ function App() {
     </Router>
   )
 }
-
-export default App

--- a/src/Header/Header.tsx
+++ b/src/Header/Header.tsx
@@ -7,9 +7,10 @@ interface HeaderProps {
 
 export default function Header({ children }: HeaderProps) {
   return (
-    <div className='headerContainer'>
-      <header className='homeHeader'>掲示板</header>
+    <header className='headerContainer'>
+      <h1 className='homeHeader'>
+        掲示板</h1>
       {children}
-    </div>
+    </header>
   )
 }

--- a/src/Home/Home.css
+++ b/src/Home/Home.css
@@ -1,4 +1,5 @@
 body {
+  margin: 0;
 }
 
 .headerContainer {

--- a/src/Home/Home.tsx
+++ b/src/Home/Home.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom';
+import Header from '../Header/Header';
+import './Home.css';
+
+type Threads = {
+  id: number;
+  title: string;
+}
+
+export default function Home() {
+  const [threads, setThreads] = useState<Threads[]>([]);
+
+  useEffect(() => {
+    fetch("https://railway.bulletinboard.techtrain.dev/threads?offset=60")
+      .then(res => res.json())
+      .then(data => setThreads(data))
+      .catch(error => {
+        console.log("スレッドのデータを取得できません", error)
+      })
+  }, []);
+  console.log(threads)
+  return (
+    <>
+      <Header>
+        <Link to="/threads/new" className='threadCreateLink' >スレッドをたてる</Link>
+      </Header >
+      <section className='threadContainer'>
+        <h1>新着スレッド</h1>
+        <ul>
+          {threads.map(thread => (
+            <li className='threadCord' key={thread.id}>{thread.title}</li>
+          ))}
+        </ul>
+      </section>
+    </>
+  )
+}

--- a/src/ThreadsCreate/ThreadsCreate.tsx
+++ b/src/ThreadsCreate/ThreadsCreate.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import "./threadsCreate.css";
 import Header from "../Header/Header";
 
 export default function ThreadsCreate() {
   const [createTitle, setCreateTitle] = useState("");
-  // TODO:response後のメッセージ表示するStateを作成
+  const navigate = useNavigate();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-
     const postData = {
       title: createTitle
     }
@@ -20,14 +20,19 @@ export default function ThreadsCreate() {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(postData),
-      });
-      console.log("スレッドの作成完了:", postData)
+      })
+        .then(res => res.json())
+        .then(data => {
+          alert("スレッドの作成完了:" + data.title);
+          setCreateTitle("");
+          navigate("/");
+        })
     }
     catch (error) {
-      console.log("スレッドのデータを取得できません", error)
+      console.log("スレッドが作成できませんでした。", error)
     }
-
   }
+
   return (
     <>
       <Header>
@@ -35,17 +40,19 @@ export default function ThreadsCreate() {
       </Header>
       <section>
         <h1>スレッド新規作成</h1>
-        <form onSubmit={handleSubmit}>
-          <label>
-            スレッドタイトル
-            <input type="text"
-              value={createTitle}
-              name="threadTitle"
-              onChange={(e) => setCreateTitle(e.target.value)}
-              placeholder="タイトルを入力してください" />
-          </label>
-          <button type="submit">作成</button>
-        </form>
+        <label>
+          スレッドタイトル
+          <input type="text"
+            value={createTitle}
+            name="threadTitle"
+            onChange={(e) => setCreateTitle(e.target.value)}
+            placeholder="タイトルを入力してください"
+          />
+        </label>
+        <button
+          onClick={handleSubmit}
+          disabled={createTitle === ""}
+        >作成</button>
       </section>
     </>
   )


### PR DESCRIPTION
- Homeコンポーネント別のファイルに切り出し
- スレッド入力フォームがからの状態のときはボタンを押せないように<button>にdisabledを追加
- useNavigateのフックを利用してスレッド新規作成後にトップページに遷移できるようにした
- Headerコンポーネントは{children}が構造上<header>内の要素であると明示的にするために<header>内に移動